### PR TITLE
Add support for URL encoded body

### DIFF
--- a/adapters/express/middleware.mjs
+++ b/adapters/express/middleware.mjs
@@ -20,13 +20,24 @@ export default async (req, res, next) => {
 };
 
 const reqToElmPagesJson = (req) => {
-  const url = `${req.protocol}://${req.host}${req.originalUrl}`;
+  const { body, headers, method } = req;
+  const rawUrl = `${req.protocol}://${req.headers.host}${req.originalUrl}`;
+  
   return {
     requestTime: Math.round(new Date().getTime()),
-    method: req.method,
-    headers: req.headers,
-    rawUrl: url,
-    body: req.body,
+    method,
+    headers,
+    rawUrl,
+    body: body && isFormData(headers) ? toFormData(body) : body && JSON.stringify(body) || null,
     multiPartFormData: null,
   };
 };
+
+const isFormData = (headers) => headers['content-type'] === 'application/x-www-form-urlencoded';
+
+const toFormData = (body) => typeof body === 'string'
+    ? body
+    : Object.entries(body).reduce((formData, [key, value]) => {
+        formData.append(key, value);
+        return formData;
+    }, new URLSearchParams()).toString() || null;

--- a/adapters/express/server.mjs
+++ b/adapters/express/server.mjs
@@ -5,6 +5,8 @@ const app = express();
 const port = 3000;
 
 app.use(express.static("dist"));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 app.use(elmPagesMiddleware);
 app.listen(port, () => {
   console.log(`Listening on port ${port}`);


### PR DESCRIPTION
If the `content-type` is `application/x-www-form-urlencoded` then we format the body as below. Otherwise, we stringify the body payload.

`key1=value1&key2=value2`

